### PR TITLE
Creates stub for theme customization

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -57,7 +57,11 @@ gettext_compact = False     # optional.
 # a list of builtin themes.
 #
 #html_theme = 'alabaster'
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'rtd_qgis'
+
+# Add any paths that contain custom themes here, relative to this directory.
+html_theme_path = ['../themes']
+
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/themes/rtd_qgis/static/css/qgis_docs.css
+++ b/themes/rtd_qgis/static/css/qgis_docs.css
@@ -1,0 +1,7 @@
+/* Import rtd theme */
+@import url(theme.css);
+
+/* Customize for QGIS Documentation*/
+.rst-content .guilabel {
+ background:#7fbbe3
+}

--- a/themes/rtd_qgis/theme.conf
+++ b/themes/rtd_qgis/theme.conf
@@ -1,0 +1,7 @@
+[theme]
+inherit = sphinx_rtd_theme
+stylesheet = css/qgis_docs.css
+
+[options]
+style_external_links = True
+github_url = https://github.com/rduivenvoorde/qgisdoc


### PR DESCRIPTION
Been investigating the customization of the RDT theme. I think the best way is to create a theme that inherits it completely, and then we can add extra CSS and HTML files to customize what we need.

In this example, I have changed how guilabel looks (to a very ugly style) just to show up.